### PR TITLE
Added placeholder for isDate

### DIFF
--- a/src/main/net-placeholders/IsDatePlaceholderHandler.cs
+++ b/src/main/net-placeholders/IsDatePlaceholderHandler.cs
@@ -34,7 +34,7 @@ namespace Org.XmlUnit.Placeholder
         /// <inheritdoc/>
         public ComparisonResult Evaluate(string testText)
         {
-            var result = DateTime.TryParse(testText, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date);
+            var result = DateTime.TryParse(testText, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
             return result
                 ? ComparisonResult.EQUAL
                 : ComparisonResult.DIFFERENT;

--- a/src/main/net-placeholders/IsDatePlaceholderHandler.cs
+++ b/src/main/net-placeholders/IsDatePlaceholderHandler.cs
@@ -1,0 +1,43 @@
+﻿/*
+  This file is licensed to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+using Org.XmlUnit.Diff;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Org.XmlUnit.Placeholder
+{
+    /// <summary>
+    /// Handler for the "isDate" handler placeholder keyword
+    /// </summary>
+    public class IsDatePlaceholderHandler : IPlaceholderHandler
+    {
+        private const string _keyword = "isDate";
+
+        /// <inheritdoc/>
+        public string Keyword => _keyword;
+
+        /// <inheritdoc/>
+        public ComparisonResult Evaluate(string testText)
+        {
+            var result = DateTime.TryParse(testText, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date);
+            return result
+                ? ComparisonResult.EQUAL
+                : ComparisonResult.DIFFERENT;
+        }
+    }
+}

--- a/src/main/net-placeholders/IsDatePlaceholderHandler.cs
+++ b/src/main/net-placeholders/IsDatePlaceholderHandler.cs
@@ -34,7 +34,7 @@ namespace Org.XmlUnit.Placeholder
         /// <inheritdoc/>
         public ComparisonResult Evaluate(string testText)
         {
-            var result = DateTime.TryParse(testText, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
+            var result = DateTime.TryParse(testText, out _);
             return result
                 ? ComparisonResult.EQUAL
                 : ComparisonResult.DIFFERENT;

--- a/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
+++ b/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
@@ -31,6 +31,8 @@ namespace Org.XmlUnit.Placeholder
         [Test]
         [TestCase("19/06/2020", "en-GB", TestName = "ShouldEvaluateUKDate", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("06/19/2020", "en-US", TestName = "ShouldEvaluateUSDate", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("19/06/2020", "fr-FR", TestName = "ShouldEvaluateFRDate", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("19/06/2020", "es-ES", TestName = "ShouldEvaluateESDate", ExpectedResult = ComparisonResult.EQUAL)]
         public ComparisonResult EvaluateOtherCulturesTest(string testText, string cultureCode)
         {
             CultureInfo.CurrentCulture = new CultureInfo(cultureCode);

--- a/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
+++ b/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
@@ -13,8 +13,11 @@ namespace Org.XmlUnit.Placeholder
         private IPlaceholderHandler placeholderHandler = new IsDatePlaceholderHandler();
 
         [Test()]
-        [TestCase("2020-01-01", TestName = "ShouldEvaluateDateWithDashes", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("01-01-2020", TestName = "ShouldEvaluateDateWithDashes", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("01/01/2020", TestName = "ShouldEvaluateDateWithDots", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("01/01/2020", TestName = "ShouldEvaluateDateWithSlashes", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("2020-01-01T15:00", TestName = "ShouldEvaluateSortableDate", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("2020-01-01 15:00:00Z", TestName = "ShouldEvaluateUniversalDate", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("19/06/2020", TestName = "ShouldEvaluateUKDate", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("06/19/2020", TestName = "ShouldEvaluateUSDate", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("01/01/2020 15:00", TestName = "ShouldEvaluateDateWithTime", ExpectedResult = ComparisonResult.EQUAL)]

--- a/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
+++ b/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
@@ -3,6 +3,7 @@ using Org.XmlUnit.Diff;
 using Org.XmlUnit.Placeholder;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace Org.XmlUnit.Placeholder
@@ -12,20 +13,27 @@ namespace Org.XmlUnit.Placeholder
     {
         private IPlaceholderHandler placeholderHandler = new IsDatePlaceholderHandler();
 
-        [Test()]
+        [Test]
         [TestCase("01-01-2020", TestName = "ShouldEvaluateDateWithDashes", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("01/01/2020", TestName = "ShouldEvaluateDateWithDots", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("01/01/2020", TestName = "ShouldEvaluateDateWithSlashes", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("2020-01-01T15:00", TestName = "ShouldEvaluateSortableDate", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("2020-01-01 15:00:00Z", TestName = "ShouldEvaluateUniversalDate", ExpectedResult = ComparisonResult.EQUAL)]
-        [TestCase("19/06/2020", TestName = "ShouldEvaluateUKDate", ExpectedResult = ComparisonResult.EQUAL)]
-        [TestCase("06/19/2020", TestName = "ShouldEvaluateUSDate", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase("01/01/2020 15:00", TestName = "ShouldEvaluateDateWithTime", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase(null, TestName = "ShouldNotEvaluateNull", ExpectedResult = ComparisonResult.DIFFERENT)]
         [TestCase("", TestName = "ShouldNotEvaluateEmpty", ExpectedResult = ComparisonResult.DIFFERENT)]
         [TestCase("This is a test date 01/01/2020", TestName = "ShouldNotEvaluateStringContainingDate", ExpectedResult = ComparisonResult.DIFFERENT)]
         public ComparisonResult EvaluateTest(string testText)
         {
+            return placeholderHandler.Evaluate(testText);
+        }
+
+        [Test]
+        [TestCase("19/06/2020", "en-GB", TestName = "ShouldEvaluateUKDate", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("06/19/2020", "en-US", TestName = "ShouldEvaluateUSDate", ExpectedResult = ComparisonResult.EQUAL)]
+        public ComparisonResult EvaluateOtherCulturesTest(string testText, string cultureCode)
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureCode);
             return placeholderHandler.Evaluate(testText);
         }
 

--- a/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
+++ b/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using Org.XmlUnit.Diff;
+using Org.XmlUnit.Placeholder;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Org.XmlUnit.Placeholder
+{
+    [TestFixture()]
+    public class IsDatePlaceholderHandlerTests
+    {
+        private IPlaceholderHandler placeholderHandler = new IsDatePlaceholderHandler();
+
+        [Test()]
+        [TestCase("2020-01-01", TestName = "ShouldEvaluateDateWithDashes", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("01/01/2020", TestName = "ShouldEvaluateDateWithSlashes", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("19/06/2020", TestName = "ShouldEvaluateUKDate", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("06/19/2020", TestName = "ShouldEvaluateUSDate", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase("01/01/2020 15:00", TestName = "ShouldEvaluateDateWithTime", ExpectedResult = ComparisonResult.EQUAL)]
+        [TestCase(null, TestName = "ShouldNotEvaluateNull", ExpectedResult = ComparisonResult.DIFFERENT)]
+        [TestCase("", TestName = "ShouldNotEvaluateEmpty", ExpectedResult = ComparisonResult.DIFFERENT)]
+        public ComparisonResult EvaluateTest(string testText)
+        {
+            return placeholderHandler.Evaluate(testText);
+        }
+
+        [Test]
+        public void ShouldGetKeyword()
+        {
+            string expected = "isDate";
+            string keyword = placeholderHandler.Keyword;
+
+            Assert.AreEqual(expected, keyword);
+        }
+    }
+}

--- a/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
+++ b/src/tests/net-placeholders/IsDatePlaceholderHandlerTests.cs
@@ -20,6 +20,7 @@ namespace Org.XmlUnit.Placeholder
         [TestCase("01/01/2020 15:00", TestName = "ShouldEvaluateDateWithTime", ExpectedResult = ComparisonResult.EQUAL)]
         [TestCase(null, TestName = "ShouldNotEvaluateNull", ExpectedResult = ComparisonResult.DIFFERENT)]
         [TestCase("", TestName = "ShouldNotEvaluateEmpty", ExpectedResult = ComparisonResult.DIFFERENT)]
+        [TestCase("This is a test date 01/01/2020", TestName = "ShouldNotEvaluateStringContainingDate", ExpectedResult = ComparisonResult.DIFFERENT)]
         public ComparisonResult EvaluateTest(string testText)
         {
             return placeholderHandler.Evaluate(testText);


### PR DESCRIPTION
I use the **ignore** placeholder a lot but for timestamp fields, it'd be useful to check that the value is a valid date instead of ignoring it